### PR TITLE
[Feature 10] 디테일 화면에서 저장 버튼 클릭 시 이미지 갤러리로 저장

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/objectdetection/MainViewModel.kt
+++ b/app/src/main/java/com/example/objectdetection/MainViewModel.kt
@@ -1,5 +1,13 @@
 package com.example.objectdetection
 
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.media.MediaScannerConnection
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -7,6 +15,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.objectdetection.data.Photo
 import com.example.objectdetection.repository.UnsplashRepository
 import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
 
 class MainViewModel : ViewModel() {
     private val unsplashRepository = UnsplashRepository()
@@ -14,10 +24,64 @@ class MainViewModel : ViewModel() {
     private val _photos = MutableLiveData<List<Photo>?>()
     val photos: LiveData<List<Photo>?> = _photos
 
+    private val _imageSaved = MutableLiveData<Boolean>()
+    val imageSaved: LiveData<Boolean> get() = _imageSaved
+
+
     fun searchPhotos(query: String) {
         viewModelScope.launch {
             val result = unsplashRepository.searchPhotos(query)
             _photos.value = result
+        }
+    }
+
+    fun saveImageToGallery(context: Context, bitmap: Bitmap, photoName: String) {
+        viewModelScope.launch {
+            val fileName = "${photoName}_${System.currentTimeMillis()}.jpg"
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    // Android 10 이상 (MediaStore 사용)
+                    val contentValues = ContentValues().apply {
+                        put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+                        put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+                        put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+                        put(MediaStore.Images.Media.IS_PENDING, 1)
+                    }
+
+                    val resolver = context.contentResolver
+                    val imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+
+                    imageUri?.let { uri ->
+                        resolver.openOutputStream(uri)?.use { outputStream ->
+                            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+                        }
+                        contentValues.clear()
+                        contentValues.put(MediaStore.Images.Media.IS_PENDING, 0)
+                        resolver.update(uri, contentValues, null, null)
+
+                        _imageSaved.value = true
+                    } ?: {
+                        _imageSaved.value = false
+                    }
+                } else {
+                    // Android 9 이하
+                    val directory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+                    val file = File(directory, fileName)
+
+                    val outputStream = FileOutputStream(file)
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+                    outputStream.flush()
+                    outputStream.close()
+
+                    MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf("image/jpeg"), null)
+
+                    _imageSaved.value = true
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Log.e("ObjectDetection", "image save error ${e.printStackTrace()}")
+                _imageSaved.value = false
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/objectdetection/MainViewModel.kt
+++ b/app/src/main/java/com/example/objectdetection/MainViewModel.kt
@@ -68,10 +68,9 @@ class MainViewModel : ViewModel() {
                     val directory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
                     val file = File(directory, fileName)
 
-                    val outputStream = FileOutputStream(file)
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
-                    outputStream.flush()
-                    outputStream.close()
+                    file.outputStream().use { outputStream ->
+                        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+                    }
 
                     MediaScannerConnection.scanFile(context, arrayOf(file.absolutePath), arrayOf("image/jpeg"), null)
 

--- a/app/src/main/java/com/example/objectdetection/fragment/DetailFragment.kt
+++ b/app/src/main/java/com/example/objectdetection/fragment/DetailFragment.kt
@@ -8,10 +8,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
+import com.example.objectdetection.MainViewModel
 import com.example.objectdetection.R
 import com.example.objectdetection.databinding.FragmentDetailBinding
 import java.io.File
@@ -29,6 +32,7 @@ class DetailFragment : Fragment() {
     private var _binding: FragmentDetailBinding? = null
     private val binding get() = _binding!!
     private lateinit var context: Context
+    private val viewModel by viewModels<MainViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -88,6 +92,20 @@ class DetailFragment : Fragment() {
                 }.setDataAndType(imageUri, "image/jpg")
 
                 startActivity(Intent.createChooser(shareIntent, "$photoName"))
+            }
+        }
+
+        binding.toolbar.ivDown.setOnClickListener {
+            imgBitmap?.let { image ->
+                viewModel.saveImageToGallery(context, image, photoName!!)
+            }
+        }
+
+        viewModel.imageSaved.observe(viewLifecycleOwner) { isSaved ->
+            if (isSaved) {
+                Toast.makeText(context, getString(R.string.toast_image_saved), Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(context, getString(R.string.toast_fail_image_saved), Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="api_error">Api communication error</string>
     <string name="unknown">unknown</string>
     <string name="share_image">share image</string>
+    <string name="toast_image_saved">Image successfully saved</string>
+    <string name="toast_fail_image_saved">Failed to save the image</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

#10 

## 📝작업 내용
디테일 화면에서 상단의 저장 버튼 클릭 시 토스트와 함께 이미지 갤러리로 저장되는 기능 추가 

<img width="968" alt="스크린샷 2025-01-29 오후 5 05 26" src="https://github.com/user-attachments/assets/9652c094-f76b-436f-91a0-9000f6f8b3e4" />