### PR TITLE
[Feature13] API 응답 에러 처리 방식 변경

### DIFF
--- a/app/src/main/java/com/example/objectdetection/MainViewModel.kt
+++ b/app/src/main/java/com/example/objectdetection/MainViewModel.kt
@@ -26,11 +26,18 @@ class MainViewModel : ViewModel() {
     private val _imageSaved = MutableLiveData<Boolean>()
     val imageSaved: LiveData<Boolean> get() = _imageSaved
 
+    private val _apiError = MutableLiveData<String?>()
+    val apiError: LiveData<String?> = _apiError
+
 
     fun searchPhotos(query: String) {
         viewModelScope.launch {
-            val result = unsplashRepository.searchPhotos(query)
-            _photos.value = result
+            try {
+                val result = unsplashRepository.searchPhotos(query)
+                _photos.value = result
+            } catch (exception: Exception) {
+                _apiError.value = exception.message
+            }
         }
     }
 

--- a/app/src/main/java/com/example/objectdetection/ResponseInterceptor.kt
+++ b/app/src/main/java/com/example/objectdetection/ResponseInterceptor.kt
@@ -1,0 +1,27 @@
+package com.example.objectdetection
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class ResponseInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        if (!response.isSuccessful) {
+            val errorMessage = when (response.code) {
+                400 -> "Bad Request: The request was unacceptable, often due to missing a required parameter"
+                401 -> "Unauthorized: Invalid Access Token"
+                403 -> "Forbidden: Missing permissions to perform request"
+                404 -> "Not Found: The requested resource does not exist."
+                in 500..503 -> "Server Error: An error occurred on the server side. Code: ${response.code}"
+                else -> "Unexpected response code: ${response.code}. Message: ${response.message}"
+            }
+            throw IOException(errorMessage)
+        }
+
+        return response
+    }
+
+}

--- a/app/src/main/java/com/example/objectdetection/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/objectdetection/RetrofitInstance.kt
@@ -20,7 +20,8 @@ object RetrofitInstance {
     }
 
     private val client = OkHttpClient.Builder()
-        .addInterceptor(loggingInterceptor)
+        .addInterceptor(ResponseInterceptor())
+        .addNetworkInterceptor(loggingInterceptor)
         .build()
 
     val api: UnsplashApiService = Retrofit.Builder()

--- a/app/src/main/java/com/example/objectdetection/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/objectdetection/activity/MainActivity.kt
@@ -57,6 +57,10 @@ class MainActivity : AppCompatActivity() {
                 adapter.updateData(photos)
             }
         }
+
+        viewModel.apiError.observe(this) { exceptionMessage ->
+            Toast.makeText(this@MainActivity, "$exceptionMessage", Toast.LENGTH_LONG).show()
+        }
     }
 
     private fun initSearchView() {

--- a/app/src/main/java/com/example/objectdetection/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/objectdetection/activity/MainActivity.kt
@@ -27,7 +27,6 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
-        val apiErrorMessage = getString(R.string.api_error)
 
         setContentView(binding.root)
         initSearchView()
@@ -53,13 +52,11 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        viewModel.photos.observe(this, Observer { photos ->
+        viewModel.photos.observe(this) { photos ->
             photos?.let {
                 adapter.updateData(photos)
-            } ?: run {
-                Toast.makeText(this@MainActivity, apiErrorMessage, Toast.LENGTH_LONG).show()
             }
-        })
+        }
     }
 
     private fun initSearchView() {

--- a/app/src/main/java/com/example/objectdetection/repository/UnsplashRepository.kt
+++ b/app/src/main/java/com/example/objectdetection/repository/UnsplashRepository.kt
@@ -1,6 +1,5 @@
 package com.example.objectdetection.repository
 
-import android.util.Log
 import com.example.objectdetection.BuildConfig
 import com.example.objectdetection.RetrofitInstance
 import com.example.objectdetection.data.Photo
@@ -9,16 +8,11 @@ class UnsplashRepository {
     private val api = RetrofitInstance.api
     private val accessKey = BuildConfig.UNSPLASH_ACCESS_KEY
 
-    suspend fun searchPhotos(query: String): List<Photo>? {
-        return try {
-            val response = api.searchPhotos(
-                authorization = "Client-ID $accessKey",
-                query = query
-            )
-            response.results
-        } catch (e: Exception) {
-            Log.e("Unsplash", "Failure: ${e.message}", e)
-            null
-        }
+    suspend fun searchPhotos(query: String): List<Photo> {
+        val response = api.searchPhotos(
+            authorization = "Client-ID $accessKey",
+            query = query
+        )
+        return response.results
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">Snap detect</string>
-    <string name="api_error">Api communication error</string>
     <string name="unknown">unknown</string>
     <string name="share_image">share image</string>
     <string name="toast_image_saved">Image successfully saved</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

#13 

## 📝작업 내용
기존에는 null 처리로 되어있던 API 응답 에러 처리를 interceptor를 추가하여 어떤 에러로 인해 API error가 생겼는지 토스트 띄우도록 수정 (아래의 unsplash에러 코드 기준으로 토스트 작업)


<img src="https://github.com/user-attachments/assets/f45f9ee3-741b-4b40-9d25-3c92274cbafc" width="200"/>


### 참고 내용
[unsplash error](https://unsplash.com/documentation#search-photos)