### PR TITLE
[Feature23] hilt 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.dagger.hilt)
 }
 
 android {
@@ -87,6 +88,8 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.phto.view)
     implementation(libs.view.pager2)
+    implementation(libs.dagger.hilt)
+    ksp(libs.dagger.hilt.compiler)
     ksp(libs.glide.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:maxSdkVersion="28" />
 
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/objectdetection/App.kt
+++ b/app/src/main/java/com/example/objectdetection/App.kt
@@ -1,0 +1,9 @@
+package com.example.objectdetection
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class App : Application() {
+
+}

--- a/app/src/main/java/com/example/objectdetection/MainViewModel.kt
+++ b/app/src/main/java/com/example/objectdetection/MainViewModel.kt
@@ -14,12 +14,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.objectdetection.data.Photo
 import com.example.objectdetection.repository.UnsplashRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.io.File
+import javax.inject.Inject
 
-class MainViewModel : ViewModel() {
-    private val unsplashRepository = UnsplashRepository()
-
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val unsplashRepository: UnsplashRepository
+) : ViewModel() {
     private val _photos = MutableLiveData<List<Photo>?>()
     val photos: LiveData<List<Photo>?> = _photos
 
@@ -28,7 +31,6 @@ class MainViewModel : ViewModel() {
 
     private val _apiError = MutableLiveData<String?>()
     val apiError: LiveData<String?> = _apiError
-
 
     fun searchPhotos(query: String) {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/objectdetection/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/objectdetection/RetrofitInstance.kt
@@ -1,12 +1,19 @@
 package com.example.objectdetection
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import javax.inject.Singleton
 
+@Module
+@InstallIn(SingletonComponent::class)
 object RetrofitInstance {
     private const val BASE_URL = "https://api.unsplash.com/"
 
@@ -24,10 +31,19 @@ object RetrofitInstance {
         .addNetworkInterceptor(loggingInterceptor)
         .build()
 
-    val api: UnsplashApiService = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .client(client)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
-        .create(UnsplashApiService::class.java)
+    @Provides
+    @Singleton
+    fun provideRetrofit(): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideUnsplashApiService(retrofit: Retrofit): UnsplashApiService {
+        return retrofit.create(UnsplashApiService::class.java)
+    }
 }

--- a/app/src/main/java/com/example/objectdetection/activity/MainActivity.kt
+++ b/app/src/main/java/com/example/objectdetection/activity/MainActivity.kt
@@ -13,7 +13,9 @@ import com.example.objectdetection.MainViewModel
 import com.example.objectdetection.R
 import com.example.objectdetection.databinding.ActivityMainBinding
 import com.example.objectdetection.fragment.DetailViewPagerFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var adapter: ImageListAdapter

--- a/app/src/main/java/com/example/objectdetection/fragment/DetailFragment.kt
+++ b/app/src/main/java/com/example/objectdetection/fragment/DetailFragment.kt
@@ -17,9 +17,10 @@ import com.bumptech.glide.request.target.CustomTarget
 import com.example.objectdetection.MainViewModel
 import com.example.objectdetection.R
 import com.example.objectdetection.databinding.FragmentDetailBinding
+import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
 
-
+@AndroidEntryPoint
 class DetailFragment : Fragment() {
     companion object {
         private const val PHOTO_URL = "photoUrl"

--- a/app/src/main/java/com/example/objectdetection/repository/UnsplashRepository.kt
+++ b/app/src/main/java/com/example/objectdetection/repository/UnsplashRepository.kt
@@ -1,11 +1,13 @@
 package com.example.objectdetection.repository
 
 import com.example.objectdetection.BuildConfig
-import com.example.objectdetection.RetrofitInstance
+import com.example.objectdetection.UnsplashApiService
 import com.example.objectdetection.data.Photo
+import javax.inject.Inject
 
-class UnsplashRepository {
-    private val api = RetrofitInstance.api
+class UnsplashRepository @Inject constructor(
+    private val api: UnsplashApiService
+) {
     private val accessKey = BuildConfig.UNSPLASH_ACCESS_KEY
 
     suspend fun searchPhotos(query: String): List<Photo> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.serialization) apply false
+    alias(libs.plugins.dagger.hilt) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ serialization = "1.6.0"
 retrofit2-kotlinx-serialization-converter = "0.8.0"
 photo-view = "2.3.0"
 view-pager2 = "1.0.0"
+hilt = "2.51.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,12 +55,15 @@ glide-compiler = { module = "com.github.bumptech.glide:ksp", version.ref = "glid
 retrofit2-kotlinx-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2-kotlinx-serialization-converter" }
 # kotlinx.serialization을 위한 라이브러리
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
-fragment = {module = "androidx.fragment:fragment-ktx", version.ref = "fragment"}
-phto-view = {module = "com.github.chrisbanes:PhotoView", version.ref = "photo-view"}
-view-pager2 = {module = "androidx.viewpager2:viewpager2", version.ref = "view-pager2"}
+fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
+phto-view = { module = "com.github.chrisbanes:PhotoView", version.ref = "photo-view" }
+view-pager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "view-pager2" }
+dagger-hilt = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+dagger-hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "serialization" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }


### PR DESCRIPTION
## #️⃣연관된 이슈

#23 

## 📝작업 내용

Hilt를 사용하여 의존성 주입을 적용하고 코드의 유지보수성을 개선하였습니다.
Hilt는 Android 공식 DI 솔루션으로 Dagger의 성능을 유지하면서 설정이 간편하고 Jetpack과 완벽히 연동가능 해 Hilt로 선택하였습니다.

1. Viewmodel 의존성 주입
`@HiltViewModel`을 추가하여 MainViewmodel을 Hilt에서 관리하도록 변경
`UnsplashRepository`를 생성자 주입하여 종송석 정의

2. Repository 의존성 주입
`UnsplashRepository`에 `@Inject`를 추가하여 Hilt가 자동으로 관리하도록 설정
API통신을 위한 `UnsplashApiService`를 생성자 주입

3. Retrofit 의존성 주입
`@Provides`와 `@Singleton`을 사용하여 `Retrofit`과 `UnsplashApiService`를 DI 컨테이너에서 관리하도록 설정
API 호출 시 객체를 매번 생성하지 않고, 하나의 인스턴스를 공유하도록 개선



### 참고 내용
[Hilt android developers](https://developer.android.com/training/dependency-injection/hilt-android?hl=ko)